### PR TITLE
Release 0.1.4: docs app, CLI harmonization, isolate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4] - 2025-09-08
+### Added
+- New `docs` app type: navigate Markdown as commands (files) and sub-apps (folders)
+  - Recursive navigation with space-separated or colon shorthand (`a:b:c`)
+  - Include directives on a single line: `@path/to/file.md` (configurable via `meta.respect_include`)
+  - Exclusions via `meta.exclude` glob patterns (affects listing, navigation, and includes)
+  - Agent-friendly behavior: hide empty folders; flatten folder-only trees into `a:b[:c]`
+  - Output normalization: ensure a single trailing newline when printing files
+- CLI help harmonization across app types (MCP, MCP-Remote, Docs):
+  - Unified sections: `<app> commands` and `<app> sub-apps`
+  - Usage hints for immediate run and detailed help
+- App listing header updated: `📦 Available apps:`
+
+### Changed
+- `tasak <app>` behavior now falls back to grouped help unless there is exactly one command with no required params (then it runs immediately).
+
+### Docs
+- README: Replace “Three Modes of Power” with “Useful Node Types (App Types)” and add examples for all types, including `docs`.
+- basic_usage.md: Add “Docs Apps (Markdown Navigator)” section with configuration and usage.
+
 ### Added
 - Nothing yet
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Transform your AI coding assistant into a productivity powerhouse with custom tools and workflows tailored to YOUR codebase.**
 
-[![PyPI version](https://badge.fury.io/py/tasak.svg)](https://badge.fury.io/py/tasak)
+[![PyPI version](https://img.shields.io/pypi/v/tasak.svg)](https://pypi.org/project/tasak/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub release](https://img.shields.io/github/release/jacekjursza/tasak.svg)](https://github.com/jacekjursza/tasak/releases/latest)
 

--- a/README.md
+++ b/README.md
@@ -130,11 +130,17 @@ TASAK exposes your tools as app “nodes” your agent can navigate. The most us
 See all node/app types and details → docs/basic_usage.md#understanding-app-types
 
 ### 🔄 **Hierarchical Config**
-Global tools + project tools = perfect setup
+Global tools + project tools = perfect setup (with optional isolation)
 ```
 ~/.tasak/tasak.yaml       # Your personal toolkit
 ./project/tasak.yaml      # Project-specific tools
 = Your AI has exactly what it needs
+```
+
+Tip: To stop inheriting from parents/global at a given level, set:
+```yaml
+apps_config:
+  isolate: true  # Ignore all higher configs above this file
 ```
 
 ## ⚡ Quick Start

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![GitHub release](https://img.shields.io/github/release/jacekjursza/tasak.svg)](https://github.com/jacekjursza/tasak/releases/latest)
 
-📋 **[See what's new in v0.1.3 →](https://github.com/jacekjursza/TASAK/blob/v0.1.3/CHANGELOG.md#013---2025-09-08)**
+📋 **[See what's new in v0.1.4 →](https://github.com/jacekjursza/TASAK/blob/v0.1.4/CHANGELOG.md#014---2025-09-08)**
 
 ## 🚀 Why TASAK?
 

--- a/README.md
+++ b/README.md
@@ -74,34 +74,60 @@ Your AI agent can write its own tools! Just ask:
 
 The agent writes the Python function, TASAK automatically loads it. Mind = blown. 🤯
 
-### 🎭 **Three Modes of Power**
+### 🧱 Useful Node Types (App Types)
 
-**`cmd` apps** - Quick & dirty commands
-```yaml
-format_code:
-  type: cmd
-  meta:
-    command: "ruff format . && ruff check --fix"
-```
+TASAK exposes your tools as app “nodes” your agent can navigate. The most useful types:
 
-**`mcp` apps** - Stateful AI-native services
-```yaml
-database:
-  type: mcp
-  meta:
-    command: "uvx mcp-server-sqlite --db ./app.db"
-```
+- `cmd` — quick shell commands
+  ```yaml
+  format_code:
+    type: cmd
+    meta:
+      command: "ruff format . && ruff check --fix"
+  ```
 
-**`curated` apps** - Orchestrated workflows
-```yaml
-full_deploy:
-  type: curated
-  commands:
-    - test
-    - build
-    - deploy
-    - notify_slack
-```
+- `docs` — Markdown navigator (commands = .md files; sub‑apps = folders)
+  ```yaml
+  docs:
+    type: docs
+    meta:
+      directory: "./docs"
+      respect_include: true
+  ```
+
+- `mcp` — local MCP server (stateful, AI‑native)
+  ```yaml
+  database:
+    type: mcp
+    meta:
+      command: "uvx mcp-server-sqlite --db ./app.db"
+  ```
+
+- `mcp-remote` — remote MCP via proxy (OAuth, SSE)
+  ```yaml
+  atlassian:
+    type: mcp-remote
+    meta:
+      server_url: "https://mcp.atlassian.com/v1/sse"
+  ```
+
+- `curated` — orchestrated workflows (compose multiple steps/tools)
+  ```yaml
+  full_deploy:
+    type: curated
+    commands:
+      - test
+      - build
+      - deploy
+      - notify_slack
+  ```
+
+- `python-plugin` — Python‑written plugins discovered from plugin dirs
+  ```yaml
+  # auto‑discovered; enable via plugins.python settings
+  ```
+
+See all node/app types and details → docs/basic_usage.md#understanding-app-types
 
 ### 🔄 **Hierarchical Config**
 Global tools + project tools = perfect setup
@@ -284,19 +310,21 @@ def smart_refactor(file_pattern: str, old_name: str, new_name: str):
 
 ## 🤖 CLI Semantics for Agents
 
-For MCP and MCP‑Remote apps, TASAK presents a predictable, agent‑friendly CLI:
+Agent‑friendly defaults across app types:
 
-- `tasak <app>` → prints only tool names (one per line). No headers or descriptions.
-- `tasak <app> <tool>` →
-  - If the tool has no required parameters: executes immediately with empty args.
-  - If the tool has required parameters: shows focused help for that tool (same as `--help`), including description and parameters with required/type info.
-- `tasak <app> <tool> --help` → always shows focused help for that single tool.
-- `tasak <app> --help` → prints grouped simplified help:
-  - "<app> commands:" — tools without required params (can run immediately) as `<name> - <description>`
-  - "<app> sub-apps (use --help to read more):" — tools with required params as `<name> - <description>`
+- `tasak <app>` →
+  - If the app exposes exactly one command with no required params: runs it immediately.
+  - Otherwise: shows grouped simplified help with sections "<app> commands:" and "<app> sub-apps:".
+- `tasak <app> <command>` →
+  - If the command has no required parameters: executes immediately.
+  - If it has required parameters: shows focused help for that command (same as `--help`).
+- `tasak <app> <command> --help` → focused help for that single command.
+- For docs apps:
+  - Navigate: `tasak <docs-app> <subdir> [subdir...]` or shorthand `tasak <docs-app> a:b[:c]`
+  - Open files: `tasak <docs-app> <sub-app...> <command>` (extension optional)
 
 Behavior notes:
-- Tool schema listing/help uses a transparent 1‑day cache; when stale or missing, TASAK refreshes quietly and updates the cache.
+- Tool schema listing/help uses a transparent cache and refreshes quietly when stale or missing.
 - Noisy transport logs are suppressed by default; enable with `TASAK_DEBUG=1` or `TASAK_VERBOSE=1` if you need to debug.
 
 ## Daemon (Connection Pooling)

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -509,3 +509,9 @@ You've learned the basics of creating and using `cmd` apps. Ready for more?
 - Explore [Advanced Usage](advanced_usage.md) - Learn about MCP servers, authentication, and complex workflows
 - Check out example configurations in the repository
 - Share your custom apps with the community!
+To make a project self-contained and ignore higher-level configs (including `~/.tasak/tasak.yaml`), set isolation at that level:
+
+```yaml
+apps_config:
+  isolate: true  # Treat this file as the root; ignore parents
+```

--- a/docs/basic_usage.md
+++ b/docs/basic_usage.md
@@ -35,10 +35,14 @@ This guide covers creating and using simple `cmd` apps - the foundation of TASAK
 
 ## Understanding App Types
 
-TASAK supports two app types:
+TASAK supports several app types:
 
-- **`cmd`**: Execute shell commands (this guide)
-- **`mcp`**: Run persistent MCP servers ([Advanced Usage](advanced_usage.md))
+- `cmd` — execute shell commands (this guide)
+- `docs` — navigate Markdown docs as commands/sub-apps (see below)
+- `mcp` — run local MCP servers ([Advanced Usage](advanced_usage.md))
+- `mcp-remote` — connect to remote MCP servers via proxy ([Advanced Usage](advanced_usage.md))
+- `curated` — composite workflows and structured interfaces ([Advanced Usage](advanced_usage.md))
+- `python-plugin` — Python-written plugins discovered from plugin dirs ([Advanced Usage](advanced_usage.md))
 
 ## Your First App
 
@@ -126,6 +130,47 @@ tasak my-workspace start
 ```
 
 For now, let's focus on simple `cmd` apps.
+
+## Docs Apps (Markdown Navigator)
+
+Docs apps expose a directory of Markdown files as a CLI that’s easy for agents:
+
+```yaml
+# ~/.tasak/tasak.yaml
+apps_config:
+  enabled_apps: [docsapp]
+
+docsapp:
+  name: "Project Docs"
+  type: "docs"
+  meta:
+    directory: "./docs"           # root of your docs
+    respect_include: true          # default; expand lines like @path/to/file.md
+    exclude:                       # optional glob patterns relative to root
+      - ".git/**"
+      - "**/_*.md"
+```
+
+Usage:
+```bash
+# List top-level docs (commands) and subfolders (sub-apps)
+tasak docsapp
+
+# Navigate (space-separated or colon shorthand)
+tasak docsapp guides deep
+tasak docsapp guides:deep
+
+# Open a Markdown file (extension optional)
+tasak docsapp guides intro
+
+# Include directive (in Markdown, as a separate line):
+# @.agent/AGENTS.md  -> inserts that file’s content
+```
+
+Behavior:
+- Empty folders are hidden; folders containing only folders are flattened in listings (e.g. `a:b:c`).
+- Outputs always end with a single trailing newline.
+- Excluded paths are silently omitted from listings; includes pointing to excluded files remain literal.
 
 ## Practical Examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tasak"
-version = "0.1.3"
+version = "0.1.4"
 authors = [
   { name="Jacek Jursza", email="okhan.pl@gmail.com" },
 ]

--- a/tasak/curated_app.py
+++ b/tasak/curated_app.py
@@ -13,6 +13,7 @@ import sys
 from typing import Any, Dict, List
 from dataclasses import dataclass
 
+from .config import load_and_merge_configs
 from .mcp_real_client import MCPRealClient
 from .core.tool_service import ToolService
 from typing import Optional
@@ -44,7 +45,6 @@ class CuratedMCPRemoteShim:
 
 # Export compatibility symbol for tests; points to shim by default
 MCPRemoteClient = CuratedMCPRemoteShim
-from .config import load_and_merge_configs
 
 
 @dataclass

--- a/tasak/daemon/manager.py
+++ b/tasak/daemon/manager.py
@@ -51,7 +51,7 @@ def is_daemon_running() -> bool:
     try:
         response = requests.get(f"{DAEMON_URL}/health", timeout=1)
         return response.status_code == 200
-    except:
+    except Exception:
         return False
 
 

--- a/tasak/daemon/server.py
+++ b/tasak/daemon/server.py
@@ -181,12 +181,7 @@ async def list_tools(app_name: str, config: Dict[str, Any] = None):
 
     except Exception as e:
         logger.error(f"[tools] error listing tools for {app_name}: {e}")
-        # Increment error metric if we have a connection object partially
-        try:
-            if "conn" in locals() and conn:
-                conn.error_count += 1
-        except Exception:
-            pass
+        # Metrics are tracked in the core manager; respond with HTTP 500
         raise HTTPException(status_code=500, detail=str(e))
 
 

--- a/tasak/docs_app.py
+++ b/tasak/docs_app.py
@@ -1,0 +1,431 @@
+"""
+Docs App Type
+
+Provides a filesystem-backed, read-only navigator for Markdown documentation.
+
+Behavior:
+- Without arguments: list root-level Markdown files as "commands" and
+  immediate subdirectories as "sub-apps".
+- With path segments: navigate into subdirectories recursively.
+- When a Markdown file is selected (with or without .md extension): print its
+  content to stdout.
+
+Configuration (in app_config):
+- type: "docs"
+- meta:
+    directory (str): Absolute or relative path to the docs root directory
+
+Examples:
+- tasak docsapp                 # list root-level docs and subfolders
+- tasak docsapp guides         # list docs in ./guides
+- tasak docsapp guides intro   # print ./guides/intro.md
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from pathlib import PurePosixPath
+from typing import Dict, List, Tuple
+
+
+def run_docs_app(app_name: str, app_config: Dict[str, any], app_args: List[str]):
+    """Run a docs app with recursive navigation.
+
+    Path traversal is based on tokens after the app name. The final target may
+    be a directory (list) or a Markdown file (print content). The root directory
+    is defined by meta.directory (or meta.dir as a fallback).
+    """
+    meta = app_config.get("meta", {}) or {}
+    base_dir_str = meta.get("directory") or meta.get("dir")
+    respect_include = meta.get("respect_include", True)
+    exclude_patterns = _normalize_exclude_patterns(meta.get("exclude"))
+    if not base_dir_str:
+        print("Error: 'meta.directory' not specified for docs app.", file=sys.stderr)
+        sys.exit(1)
+    base_dir = Path(base_dir_str).expanduser().resolve()
+    if not base_dir.exists() or not base_dir.is_dir():
+        print(
+            f"Error: docs directory does not exist or is not a directory: {base_dir}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    # Special: explicit help
+    if any(a in ("--help", "-h") for a in app_args):
+        _print_help(app_name, base_dir)
+        return
+
+    # Build target path from non-flag args. Support colon-joined shorthand
+    # like "folder:sub1:sub2" in addition to space-separated segments.
+    segments: List[str] = []
+    for raw in app_args:
+        if raw.startswith("-"):
+            continue
+        if ":" in raw:
+            parts = [p for p in raw.split(":") if p]
+            segments.extend(parts)
+        else:
+            segments.append(raw)
+    target_path = (base_dir.joinpath(*segments)).resolve() if segments else base_dir
+
+    # Prevent path escape outside base_dir
+    try:
+        target_path.relative_to(base_dir)
+    except Exception:
+        print("Error: Path escapes the configured docs directory.", file=sys.stderr)
+        sys.exit(1)
+
+    # If directory -> list entries; if file (with or without .md) -> print contents
+    if target_path.is_dir():
+        # Exclusion: silently fall back to parent listing (agent-friendly)
+        if _is_excluded(target_path, base_dir, exclude_patterns):
+            parent = target_path.parent if target_path != base_dir else base_dir
+            _list_dir(app_name, base_dir, parent, exclude_patterns=exclude_patterns)
+            return
+        _list_dir(app_name, base_dir, target_path, exclude_patterns=exclude_patterns)
+        return
+
+    # Handle file selection: allow implicit .md extension
+    if target_path.is_file() and target_path.suffix.lower() == ".md":
+        if _is_excluded(target_path, base_dir, exclude_patterns):
+            _list_dir(
+                app_name,
+                base_dir,
+                target_path.parent,
+                exclude_patterns=exclude_patterns,
+            )
+            return
+        _print_file(
+            target_path,
+            base_dir,
+            respect_include=respect_include,
+            exclude_patterns=exclude_patterns,
+        )
+        return
+    md_candidate = target_path.with_suffix(".md")
+    if md_candidate.is_file():
+        if _is_excluded(md_candidate, base_dir, exclude_patterns):
+            _list_dir(
+                app_name,
+                base_dir,
+                md_candidate.parent,
+                exclude_patterns=exclude_patterns,
+            )
+            return
+        _print_file(
+            md_candidate,
+            base_dir,
+            respect_include=respect_include,
+            exclude_patterns=exclude_patterns,
+        )
+        return
+
+    # Not found (agent-friendly note)
+    print("Path not found — listing parent.", file=sys.stderr)
+    # Provide a hint with a listing of the nearest existing parent
+    existing_parent = target_path
+    while not existing_parent.exists() and existing_parent != existing_parent.parent:
+        existing_parent = existing_parent.parent
+    if existing_parent.exists() and existing_parent.is_dir():
+        _list_dir(app_name, base_dir, existing_parent)
+    sys.exit(1)
+
+
+def _list_dir(
+    app_name: str,
+    base_dir: Path,
+    path: Path,
+    *,
+    exclude_patterns: List[str] | None = None,
+):
+    """List Markdown files (commands) and subdirectories (sub-apps)."""
+    # Gather immediate children
+    try:
+        entries = list(path.iterdir())
+    except PermissionError:
+        print("Error: Permission denied while listing directory.", file=sys.stderr)
+        sys.exit(1)
+
+    exclude_patterns = exclude_patterns or []
+    md_files = []
+    raw_subdirs = []
+    for p in entries:
+        if _is_excluded(p, base_dir, exclude_patterns):
+            continue
+        if p.is_file() and p.suffix.lower() == ".md":
+            md_files.append(p)
+        elif p.is_dir():
+            raw_subdirs.append(p)
+    md_files.sort(key=lambda p: p.name.lower())
+    raw_subdirs.sort(key=lambda p: p.name.lower())
+
+    # Compute flattened sub-apps: hide empty dirs; if a dir contains only dirs
+    # (recursively), present as colon-joined paths pointing to deeper nodes
+    subapps: List[Tuple[str, Path]] = []  # (display_name, real_path)
+    for d in raw_subdirs:
+        subapps.extend(_flatten_dir_for_listing(d, base_dir, exclude_patterns))
+
+    # Pretty header based on relative path
+    rel = path.relative_to(base_dir)
+    where = "/" if str(rel) == "." else f"/{rel.as_posix()}"
+    print(f'"{app_name}" at {where}')
+
+    # Commands
+    print(f'"{app_name}" commands:')
+    if md_files:
+        for f in md_files:
+            name = f.stem
+            print(f"  {name}")
+    else:
+        print("  (none)")
+
+    # Sub-apps
+    print(f'\n"{app_name}" sub-apps:')
+    if subapps:
+        names = ", ".join(n for n, _ in subapps)
+        print(f"  {names}")
+    else:
+        print("  (none)")
+
+    # Usage hint
+    bin_name = _get_binary_name()
+    print(
+        f"\nUse: {bin_name} {app_name} <subdir> [subdir...]        # Navigate",
+    )
+    print(
+        f"     {bin_name} {app_name} <a:b[:c]>               # Navigate (shorthand)",
+    )
+    print(
+        f"     {bin_name} {app_name} <sub-app...> <command>  # Open Markdown",
+    )
+
+
+def _print_file(
+    path: Path,
+    base_dir: Path,
+    *,
+    respect_include: bool = True,
+    exclude_patterns: List[str] | None = None,
+):
+    """Print the contents of a Markdown file to stdout.
+
+    Ensures a trailing newline and optionally expands include directives of the
+    form '@relative/path/to/file.md' placed on a single line.
+    """
+    text = _read_markdown_with_includes(
+        path,
+        base_dir,
+        respect_include=respect_include,
+        exclude_patterns=exclude_patterns or [],
+    )
+    if not text.endswith("\n"):
+        text += "\n"
+    sys.stdout.write(text)
+
+
+def _read_text(path: Path) -> str:
+    try:
+        return path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return path.read_text(encoding="latin-1", errors="replace")
+
+
+def _read_markdown_with_includes(
+    path: Path,
+    base_dir: Path,
+    *,
+    respect_include: bool = True,
+    exclude_patterns: List[str] = None,
+    _depth: int = 0,
+    _max_depth: int = 20,
+) -> str:
+    """Read Markdown and expand '@<relpath>' include directives line-by-line.
+
+    - Paths are resolved relative to the current file's directory, falling back
+      to base_dir, and must remain within base_dir. Only .md files are included.
+    - Recursion depth is limited to prevent cycles.
+    """
+    text = _read_text(path)
+    if not respect_include:
+        return text
+    if _depth >= _max_depth:
+        return text
+
+    lines = text.splitlines()
+    out_lines: List[str] = []
+    cur_dir = path.parent
+    for line in lines:
+        stripped = line.strip()
+        if stripped.startswith("@") and (" " not in stripped and "\t" not in stripped):
+            inc_rel = stripped[1:]
+            inc_path = (cur_dir / inc_rel).resolve()
+
+            # Constrain to base_dir
+            def _within_base(p: Path) -> bool:
+                try:
+                    p.relative_to(base_dir)
+                    return True
+                except Exception:
+                    return False
+
+            if not _within_base(inc_path):
+                inc_path = (base_dir / inc_rel).resolve()
+            if (
+                _within_base(inc_path)
+                and not _is_excluded(inc_path, base_dir, exclude_patterns or [])
+                and inc_path.is_file()
+                and inc_path.suffix.lower() == ".md"
+            ):
+                included = _read_markdown_with_includes(
+                    inc_path,
+                    base_dir,
+                    respect_include=respect_include,
+                    exclude_patterns=exclude_patterns or [],
+                    _depth=_depth + 1,
+                )
+                out_lines.append(included.rstrip("\n"))
+                continue
+        out_lines.append(line)
+
+    return "\n".join(out_lines)
+
+
+def _normalize_exclude_patterns(value) -> List[str]:
+    """Normalize exclude patterns to a list of POSIX-style globs.
+
+    Accepts None, a single string, or a list of strings. Patterns are used with
+    PurePosixPath.match on the path relative to base_dir, so they should be
+    specified relative to the docs root, e.g.:
+      - ".git/**" (exclude any .git directory)
+      - "guides/deep/**" (exclude a specific sub-tree)
+      - "**/_*.md" (exclude underscore-prefixed md files anywhere)
+      - "changelog.md" (exclude a root-level file)
+    """
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(v) for v in value if isinstance(v, (str, bytes))]
+    return []
+
+
+def _is_excluded(path: Path, base_dir: Path, patterns: List[str]) -> bool:
+    """Return True if the path matches any exclude pattern.
+
+    Matching is done against the POSIX-style relative path from base_dir.
+    """
+    try:
+        rel = path.relative_to(base_dir)
+    except Exception:
+        return False
+    rel_str = rel.as_posix()
+    rel_posix = PurePosixPath(rel_str)
+    for pat in patterns or []:
+        try:
+            if rel_posix.match(pat):
+                return True
+            # Special-case dir globs ending with '/**' to also exclude the dir itself
+            if pat.endswith("/**"):
+                base_pat = pat[:-3].rstrip("/")
+                if base_pat and rel_str == base_pat:
+                    return True
+        except Exception:
+            # Ignore bad patterns gracefully
+            continue
+    return False
+
+
+def _dir_contains_visible_md(path: Path, base_dir: Path, patterns: List[str]) -> bool:
+    try:
+        for entry in path.iterdir():
+            if _is_excluded(entry, base_dir, patterns):
+                continue
+            if entry.is_file() and entry.suffix.lower() == ".md":
+                return True
+        return False
+    except PermissionError:
+        return False
+
+
+def _flatten_dir_for_listing(
+    path: Path,
+    base_dir: Path,
+    patterns: List[str],
+    _depth: int = 0,
+    _max_depth: int = 50,
+) -> List[Tuple[str, Path]]:
+    """Return flattened sub-app entries (display_name, real_path) for a dir.
+
+    Rules:
+    - If the directory contains any visible .md files → return [(name, path)]
+      (no flattening at this level).
+    - Otherwise, if it has visible child directories, recurse into each and
+      prefix this dir's name joined by ':' to their display names.
+    - If it has no visible md and no non-empty child dirs → return [] (hidden).
+    - Do not recurse into symlink directories to avoid cycles; treat them as
+      regular entries (no flattening) so they appear as a simple sub-app.
+    """
+    if _depth >= _max_depth:
+        return [(path.name, path)]
+
+    # Avoid deep flatten on symlinks
+    try:
+        if path.is_symlink():
+            return [(path.name, path)]
+    except OSError:
+        return []
+
+    if _dir_contains_visible_md(path, base_dir, patterns):
+        return [(path.name, path)]
+
+    # Gather visible subdirs
+    try:
+        children = [
+            p
+            for p in sorted(path.iterdir(), key=lambda p: p.name.lower())
+            if p.is_dir() and not _is_excluded(p, base_dir, patterns)
+        ]
+    except PermissionError:
+        children = []
+
+    results: List[Tuple[str, Path]] = []
+    for c in children:
+        flattened = _flatten_dir_for_listing(
+            c, base_dir, patterns, _depth=_depth + 1, _max_depth=_max_depth
+        )
+        if not flattened:
+            continue
+        for disp, real in flattened:
+            results.append((f"{path.name}:{disp}", real))
+
+    return results
+
+
+def _print_help(app_name: str, base_dir: Path):
+    """Show help for docs app and list root-level entries."""
+    print(f"{app_name}")
+    print("Type: docs")
+    print(f"Root: {base_dir}")
+    print()
+    _list_dir(app_name, base_dir, base_dir)
+
+
+def _get_binary_name() -> str:
+    # Try to follow main/mcp_parser behavior
+    env_bin = os.environ.get("TASAK_BIN_NAME")
+    if env_bin:
+        return env_bin
+    argv0 = os.path.basename(sys.argv[0] or "")
+    if argv0 and argv0 not in {"python", "python3", "py", "pytest", "-m"}:
+        return argv0
+    cfg = os.environ.get("TASAK_CONFIG_NAME", "").strip()
+    if cfg:
+        base = os.path.basename(cfg)
+        if base.lower().endswith((".yaml", ".yml")):
+            base = base.rsplit(".", 1)[0]
+        if base:
+            return base
+    return "tasak"

--- a/tasak/main.py
+++ b/tasak/main.py
@@ -11,6 +11,7 @@ from tasak.python_plugins import integrate_plugins_into_config, run_python_plugi
 from tasak.curated_app import run_curated_app
 from tasak.mcp_client import run_mcp_app
 from tasak.mcp_remote_runner import run_mcp_remote_app
+from tasak.docs_app import run_docs_app
 from tasak.init_command import handle_init_command
 
 
@@ -295,6 +296,8 @@ def main():
         run_mcp_remote_app(app_name, app_config, unknown_args)
     elif app_type == "python-plugin":
         run_python_plugin(app_name, app_config, unknown_args)
+    elif app_type == "docs":
+        run_docs_app(app_name, app_config, unknown_args)
     else:
         print(
             f"Error: Unknown app type '{app_type}' for app '{app_name}'.",
@@ -319,7 +322,7 @@ def _list_available_apps(config: Dict[str, Any], simple: bool = False):
     print("=" * 50)
 
     # Always show the section header so helpers can rely on it
-    print("\n📦 Available applications:")
+    print("\n📦 Available apps:")
 
     if not enabled_apps:
         # No apps configured: show friendly guidance and an example

--- a/tasak/mcp_parser.py
+++ b/tasak/mcp_parser.py
@@ -392,8 +392,16 @@ def show_simplified_app_help(
             replace_whitespace=True,
         )
         print(wrapped_names)
-        # Show a concise hint for detailed help (dynamic binary name)
-        binary = _get_binary_name()
-        print(f"\nUse: {binary} {app_name} <sub-app> --help  # Details for that tool")
     else:
         print("  (none)")
+
+    # Usage hints (consistent with docs app style)
+    binary = _get_binary_name()
+    # Immediate run hints for commands
+    if commands:
+        print(
+            f"\nRun: {binary} {app_name} <command>            # Runs immediately (no params)"
+        )
+    # Details for sub-apps
+    if subapps:
+        print(f"Use: {binary} {app_name} <sub-app> --help   # Details and parameters")

--- a/tests/e2e/test_e2e_direct.py
+++ b/tests/e2e/test_e2e_direct.py
@@ -173,8 +173,11 @@ class TestRealApps:
                 assert e.code == 0
 
             captured = capsys.readouterr()
-            # Should list at least some apps
-            assert "Available applications:" in captured.out
+            # Should list at least some apps (header present)
+            assert (
+                "Available apps:" in captured.out
+                or "Available applications:" in captured.out
+            )
             # Check for some known apps from user's config
             assert "auth" in captured.out or "atlassian" in captured.out
 

--- a/tests/test_docs_app.py
+++ b/tests/test_docs_app.py
@@ -1,0 +1,177 @@
+from pathlib import Path
+from unittest.mock import patch
+
+from tasak.docs_app import run_docs_app
+
+
+def _make_fs(tmp_path: Path):
+    # root
+    (tmp_path / "readme.md").write_text("# Readme\nroot file\n", encoding="utf-8")
+    (tmp_path / "changelog.md").write_text("Changelog\n", encoding="utf-8")
+    # subdir guides
+    guides = tmp_path / "guides"
+    guides.mkdir()
+    (guides / "intro.md").write_text("Intro\n", encoding="utf-8")
+    deep = guides / "deep"
+    deep.mkdir()
+    (deep / "nested.md").write_text("Nested\n", encoding="utf-8")
+    # include dir
+    agent = tmp_path / ".agent"
+    agent.mkdir()
+    # Create file WITHOUT trailing newline to test newline append
+    (agent / "AGENTS.md").write_text("Agents header", encoding="utf-8")
+
+
+def _app_config(tmp_path: Path):
+    return {"type": "docs", "meta": {"directory": str(tmp_path)}}
+
+
+def test_docs_list_root(tmp_path, capsys):
+    _make_fs(tmp_path)
+    cfg = _app_config(tmp_path)
+    run_docs_app("docsapp", cfg, [])
+    out = capsys.readouterr().out
+    assert '"docsapp" commands:' in out
+    assert "readme" in out and "changelog" in out
+    assert '"docsapp" sub-apps:' in out and "guides" in out
+
+
+def test_docs_navigate_and_list(tmp_path, capsys):
+    _make_fs(tmp_path)
+    cfg = _app_config(tmp_path)
+    run_docs_app("docsapp", cfg, ["guides"])
+    out = capsys.readouterr().out
+    assert '"docsapp" commands:' in out and "intro" in out
+    assert '"docsapp" sub-apps:' in out and "deep" in out
+
+
+def test_docs_view_file_without_ext(tmp_path, capsys):
+    _make_fs(tmp_path)
+    cfg = _app_config(tmp_path)
+    run_docs_app("docsapp", cfg, ["guides", "intro"])
+    out = capsys.readouterr().out
+    assert "Intro" in out
+
+
+def test_docs_view_file_with_ext(tmp_path, capsys):
+    _make_fs(tmp_path)
+    cfg = _app_config(tmp_path)
+    run_docs_app("docsapp", cfg, ["guides", "deep", "nested.md"])
+    out = capsys.readouterr().out
+    assert "Nested" in out
+
+
+def test_docs_not_found_lists_parent(tmp_path, capsys):
+    _make_fs(tmp_path)
+    cfg = _app_config(tmp_path)
+    with patch("sys.exit") as mock_exit:
+        run_docs_app("docsapp", cfg, ["guides", "missing"])
+        mock_exit.assert_called()
+    out = capsys.readouterr().out
+    # Should list the parent directory (guides)
+    assert '"docsapp" commands:' in out and "intro" in out
+
+
+def test_docs_include_expansion_default_enabled(tmp_path, capsys):
+    _make_fs(tmp_path)
+    # Create a file that includes another
+    (tmp_path / "with_include.md").write_text(
+        "Before\n@.agent/AGENTS.md\nAfter", encoding="utf-8"
+    )
+    cfg = _app_config(tmp_path)
+    run_docs_app("docsapp", cfg, ["with_include"])
+    out = capsys.readouterr().out
+    # Included content appears and output ends with a newline
+    assert "Before" in out
+    assert "Agents header" in out
+    assert "After" in out
+    assert out.endswith("\n")
+
+
+def test_docs_include_disabled_via_config(tmp_path, capsys):
+    _make_fs(tmp_path)
+    (tmp_path / "with_include.md").write_text(
+        "Start\n@.agent/AGENTS.md\nEnd", encoding="utf-8"
+    )
+    cfg = _app_config(tmp_path)
+    cfg["meta"]["respect_include"] = False
+    run_docs_app("docsapp", cfg, ["with_include"])
+    out = capsys.readouterr().out
+    # Literal include string remains
+    assert "@.agent/AGENTS.md" in out
+
+
+def test_docs_exclude_patterns_listing_and_include(tmp_path, capsys):
+    _make_fs(tmp_path)
+    # Add .git dir and extra file
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "secret.md").write_text("Top secret\n", encoding="utf-8")
+    # Create a file that tries to include an excluded file
+    (tmp_path / "tryinc.md").write_text("X\n@secret.md\nY", encoding="utf-8")
+
+    cfg = _app_config(tmp_path)
+    # Exclude .git directory, a subtree, and a specific file
+    cfg["meta"]["exclude"] = [
+        ".git/**",
+        "guides/deep/**",
+        "secret.md",
+    ]
+
+    # Root listing should not include .git or secret
+    run_docs_app("docsapp", cfg, [])
+    out = capsys.readouterr().out
+    assert ".git" not in out
+    assert "secret" not in out
+    # Guides listing should not show deep
+    run_docs_app("docsapp", cfg, ["guides"])
+    out2 = capsys.readouterr().out
+    assert "deep" not in out2
+
+    # Including an excluded file should not expand; literal line remains
+    run_docs_app("docsapp", cfg, ["tryinc"])  # prints doc
+    out3 = capsys.readouterr().out
+    assert "@secret.md" in out3
+
+
+def test_docs_flatten_only_dirs(tmp_path, capsys):
+    # Build structure:
+    # only/x/y/file.md        -> should show as 'only:x:y'
+    # folder/mid/subsub/f.md  -> should show as 'folder:mid:subsub'
+    # mixed has md at its level -> 'mixed'
+    (tmp_path / "only" / "x" / "y").mkdir(parents=True)
+    (tmp_path / "only" / "x" / "y" / "file.md").write_text("hello\n", encoding="utf-8")
+    (tmp_path / "folder" / "mid" / "subsub").mkdir(parents=True)
+    (tmp_path / "folder" / "mid" / "subsub" / "f.md").write_text(
+        "world\n", encoding="utf-8"
+    )
+    (tmp_path / "mixed").mkdir()
+    (tmp_path / "mixed" / "r.md").write_text("readme\n", encoding="utf-8")
+
+    cfg = _app_config(tmp_path)
+    run_docs_app("docsapp", cfg, [])
+    out = capsys.readouterr().out
+    # Sub-apps line should contain flattened names
+    assert '"docsapp" sub-apps:' in out
+    # flattened entries
+    assert "only:x:y" in out
+    assert "folder:mid:subsub" in out
+    # 'mixed' shouldn't be flattened because it has md at its own level
+    assert "mixed" in out
+
+
+def test_docs_colon_navigation(tmp_path, capsys):
+    # Build deeper structure and test colon-separated args
+    (tmp_path / "A" / "B" / "C").mkdir(parents=True)
+    (tmp_path / "A" / "B" / "C" / "doc.md").write_text("content\n", encoding="utf-8")
+
+    cfg = _app_config(tmp_path)
+    # Navigate to A/B using colon shorthand
+    run_docs_app("docsapp", cfg, ["A:B"])
+    out = capsys.readouterr().out
+    assert '"docsapp" at /A/B' in out
+    assert '"docsapp" sub-apps:' in out and "C" in out
+
+    # View document using colon shorthand and explicit doc name without .md
+    run_docs_app("docsapp", cfg, ["A:B:C", "doc"])
+    out2 = capsys.readouterr().out
+    assert out2.strip().startswith("content")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -26,10 +26,8 @@ class TestCleanupPool:
 
     def test_cleanup_pool_error_ignored(self):
         """Test that errors during cleanup are ignored."""
-        import concurrent.futures as cf
 
         fake_inst = MagicMock()
-        fut = cf.Future()
 
         # Make future raise when awaited
         def _raise():

--- a/tests/test_python_plugins.py
+++ b/tests/test_python_plugins.py
@@ -63,7 +63,7 @@ def test_plugin_discovery_and_listing_auto_enable(tmp_path, monkeypatch, capsys)
     tasak_main.main()
     out = capsys.readouterr().out
 
-    assert "Available applications:" in out
+    assert "Available apps:" in out or "Available applications:" in out
     assert "myplugin" in out
     assert "python-plugin" in out
 


### PR DESCRIPTION
Release 0.1.4

Highlights
- New `docs` app type: navigate Markdown as commands (files) and sub-apps (folders)
  - Recursive navigation (space-separated or colon shorthand `a:b:c`)
  - Include directives on a single line: `@path/to/file.md` (configurable via `meta.respect_include`, default true)
  - Exclusions via `meta.exclude` glob patterns (affects listing, navigation, and includes)
  - Agent-friendly behavior: hide empty folders; flatten folder-only trees into `a:b[:c]`
  - Output normalization: ensure a single trailing newline when printing files
- CLI help harmonization across app types (MCP, MCP-Remote, Docs): unified sections `<app> commands` and `<app> sub-apps`, plus usage hints.
- App listing header: `📦 Available apps:`
- New config: `apps_config.isolate: true` to stop inheritance from parent/global configs at a given level.

Docs
- README: Replace “Three Modes of Power” with “Useful Node Types (App Types)” and add examples for all types, including `docs`.
- basic_usage.md: Add “Docs Apps (Markdown Navigator)” and isolation note in Working with Project Configs.
- CHANGELOG: 0.1.4 entry added.

Quality
- Lint fixes for shared devel stability (ruff): E402, E722, F821, F841.
- Tests: 272 passed locally.

Notes
- `tasak-dev` local wrapper (for development) now behaves like standard `tasak` (no forced TASAK_CONFIG), which allows testing isolation and cascading config behavior accurately.

